### PR TITLE
Imply-4878 Update build process to publish jar to local mvn for implydata/netty

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@ pipeline {
 
     environment {
         DOCKER_REPO="repo.qa.imply.io/docker"
-        IMAGE="imply-docker/jfrog-mvn-java8:20201029.064540"
+        IMAGE="imply-docker/jfrog-mvn-java8:20201029.080735"
         RELEASE_BRANCH="3.10.6.Final-iap"
     }
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,15 +2,15 @@ pipeline {
     agent any
 
     environment {
-        DOCKER_REPO="implydata.jfrog.io/docker-local"
-        IMAGE="imply-docker/jfrog-mvn-java8:20201014.021741"
+        DOCKER_REPO="repo.qa.imply.io/docker"
+        IMAGE="imply-docker/jfrog-mvn-java8:20201029.064540"
         RELEASE_BRANCH="3.10.6.Final-iap"
     }
 
     stages {
         stage('Pull Image') {
             steps {
-                withDockerRegistry(url: "$DOCKER_REPO", credentialsId: "implydata.jfrog.io") {
+                withDockerRegistry(url: "https://$DOCKER_REPO", credentialsId: "repo.qa.imply.io") {
                     sh "docker pull $DOCKER_REPO/$IMAGE"
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,27 @@
+pipeline {
+    agent any
+    environment {
+        ECR="018895040333.dkr.ecr.us-east-1.amazonaws.com"
+        IMAGE="imply-eng/jfrog-mvn-java8:20201009-033920"
+    }
+    stages {
+
+        stage('Pull Image') {
+            steps {
+                withDockerRegistry([url: "https://$ECR", credentialsId: "ecr:us-east-1:aws"]) {
+                    sh "docker pull $ECR/$IMAGE"
+                }
+            }
+        }
+
+        stage ('Build and Publish') {
+            steps {
+                sh """
+                    echo "mvn versions:set -B -DremoveSnapshot | true" > run.sh
+                    echo "jfrog rt mvn clean install" >> run.sh
+                    docker run -v ${WORKSPACE}/.m2:/root/.m2 -v ${WORKSPACE}:/app $ECR/$IMAGE bash run.sh
+                """
+            }
+        }
+    }
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,7 +32,7 @@ pipeline {
             }
             steps {
                 sh """
-                    docker run -v ${WORKSPACE}/.m2:/root/.m2 -v ${WORKSPACE}:/app $DOCKER_REPO/$IMAGE jfrog rt mvn install
+                    docker run -v ${WORKSPACE}/.m2:/root/.m2 -v ${WORKSPACE}:/app $DOCKER_REPO/$IMAGE jfrog rt mvn install -Dmaven.test.skip
                 """
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,16 +2,16 @@ pipeline {
     agent any
 
     environment {
-        ECR="018895040333.dkr.ecr.us-east-1.amazonaws.com"
-        IMAGE="imply-eng/jfrog-mvn-java8:20201009-033920"
+        DOCKER_REPO="implydata.jfrog.io/docker-local"
+        IMAGE="imply-docker/jfrog-mvn-java8:20201014.021741"
         RELEASE_BRANCH="3.10.6.Final-iap"
     }
 
     stages {
         stage('Pull Image') {
             steps {
-                withDockerRegistry([url: "https://$ECR", credentialsId: "ecr:us-east-1:aws"]) {
-                    sh "docker pull $ECR/$IMAGE"
+                withDockerRegistry(url: "$DOCKER_REPO", credentialsId: "implydata.jfrog.io") {
+                    sh "docker pull $DOCKER_REPO/$IMAGE"
                 }
             }
         }
@@ -20,8 +20,8 @@ pipeline {
             steps {
                 sh """
                     echo "mvn versions:set -B -DremoveSnapshot | true" > run.sh
-                    echo "mvn clean package" >> run.sh
-                    docker run -v ${WORKSPACE}/.m2:/root/.m2 -v ${WORKSPACE}:/app $ECR/$IMAGE bash run.sh
+                    echo "mvn clean install" >> run.sh
+                    docker run -v ${WORKSPACE}/.m2:/root/.m2 -v ${WORKSPACE}:/app $DOCKER_REPO/$IMAGE bash run.sh
                 """
             }
         }
@@ -32,7 +32,7 @@ pipeline {
             }
             steps {
                 sh """
-                    docker run -v ${WORKSPACE}/.m2:/root/.m2 -v ${WORKSPACE}:/app $ECR/$IMAGE jfrog rt mvn install
+                    docker run -v ${WORKSPACE}/.m2:/root/.m2 -v ${WORKSPACE}:/app $DOCKER_REPO/$IMAGE jfrog rt mvn install
                 """
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,11 +1,13 @@
 pipeline {
     agent any
+
     environment {
         ECR="018895040333.dkr.ecr.us-east-1.amazonaws.com"
         IMAGE="imply-eng/jfrog-mvn-java8:20201009-033920"
+        RELEASE_BRANCH="3.10.6.Final-iap"
     }
-    stages {
 
+    stages {
         stage('Pull Image') {
             steps {
                 withDockerRegistry([url: "https://$ECR", credentialsId: "ecr:us-east-1:aws"]) {
@@ -14,12 +16,23 @@ pipeline {
             }
         }
 
-        stage ('Build and Publish') {
+        stage ('Build') {
             steps {
                 sh """
                     echo "mvn versions:set -B -DremoveSnapshot | true" > run.sh
-                    echo "jfrog rt mvn clean install" >> run.sh
+                    echo "mvn clean package" >> run.sh
                     docker run -v ${WORKSPACE}/.m2:/root/.m2 -v ${WORKSPACE}:/app $ECR/$IMAGE bash run.sh
+                """
+            }
+        }
+
+        stage ('Publish') {
+            when {
+                branch: "${RELEASE_BRANCH}"
+            }
+            steps {
+                sh """
+                    docker run -v ${WORKSPACE}/.m2:/root/.m2 -v ${WORKSPACE}:/app $ECR/$IMAGE jfrog rt mvn install
                 """
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
 
         stage ('Publish') {
             when {
-                branch: "${RELEASE_BRANCH}"
+                branch "${RELEASE_BRANCH}"
             }
             steps {
                 sh """

--- a/README.md
+++ b/README.md
@@ -1,3 +1,48 @@
+# Imply Maven Repository
+
+Update your projects to use Imply netty artifact stored in Imply Artifactory.
+
+### ~/.m2/settings.xml
+
+```
+    <servers>
+        <server>
+            <username>eng</username>
+            <password>AP8cigvgtfjXGXLig7xcFUCWqJG</password>
+            <id>repo.qa.imply.io</id>
+        </server>
+    </servers>
+```
+
+### pom.xml (in implydata/druid project, for example)
+
+```
+...
+
+    <dependencies>
+    ...
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty</artifactId>
+            <version>3.10.6.Final-iap3</version>
+        </dependency>
+    </dependencies>
+
+    <repositories>
+        <repository>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>repo.qa.imply.io</id>
+            <name>libs-release</name>
+            <url>https://repo.qa.imply.io:443/artifactory/libs-release</url>
+        </repository>
+    </repositories>
+</project>
+```
+
+
+
 # Imply Releases
 
 To create a new build to be used in Imply releases, checkout the release branch (eg: 3.10.6.Final-iap), then run


### PR DESCRIPTION
Motivation:

Publish artifact into our local maven repo, so that it can be referenced in the Druid project.

Modification:

Added Jenkins file to build and publish artifact.

Result:

The artifact is published.
https://artifactory.qa.imply.io/artifactory/webapp/#/artifacts/browse/tree/General/imply-libs-release-local/io/netty/netty

Jenkins Job
https://ci.qa.imply.io/job/imply-druid/job/netty/job/IMPLY-4878/